### PR TITLE
Allow to specify the git revision with a env vars

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -18,7 +18,7 @@ fn main() {
         .output()
     {
         Ok(u) => String::from_utf8(u.stdout).unwrap(),
-        Err(_) => String::from("HEAD"),
+        Err(_) => env::var("GIT_REV").unwrap_or(String::from("HEAD")),
     };
 
     fs::write(


### PR DESCRIPTION
When building on Openshift, the environment is cleaned on purpose. To get the revision used, one as to set it explicitely with a variable.